### PR TITLE
Add missing call to composer create-project silverstripe/ozzy

### DIFF
--- a/ss_provision.sh
+++ b/ss_provision.sh
@@ -262,4 +262,8 @@ if [ ! -f /vagrant/composer.phar ]
   cd /vagrant
   curl -sS https://getcomposer.org/installer | php
 
+  if [ ! -f /var/www/build.xml ]
+    then
+    /vagrant/composer.phar create-project -s dev silverstripe/ozzy /var/www
+  fi
 fi


### PR DESCRIPTION
Needed to make this environment actually install SilverStripe.
